### PR TITLE
Allow mapWig & repTimeWig to be optional

### DIFF
--- a/R/runIchorCNA.R
+++ b/R/runIchorCNA.R
@@ -47,8 +47,9 @@
 #' @param outDir  Output Directory.
 #' @param cores  Number of cores to use for EM. 
 #' @export
-run_ichorCNA <- function(tumor_wig, normal_wig = NULL, gcWig, mapWig, repTimeWig, normal_panel=NULL, sex = NULL, exons.bed=NULL, id = "test", 
-             centromere = NULL, minMapScore = 0.9, flankLength = 1e5, normal=0.5, estimatePloidy = TRUE, maxFracCNASubclone = 0.7,
+run_ichorCNA <- function(tumor_wig, normal_wig = NULL, gcWig, mapWig = NULL, repTimeWig = NULL, 
+             normal_panel = NULL, sex = NULL, exons.bed = NULL, id = "test", centromere = NULL, 
+             minMapScore = 0.9, flankLength = 1e5, normal=0.5, estimatePloidy = TRUE, maxFracCNASubclone = 0.7,
              normal.init = "c(0.5, 0.5)", scStates = NULL, scPenalty = 0.1, normal2IgnoreSC = 1.0,
              coverage = NULL, likModel = "t", lambda = NULL, lambdaScaleHyperParam = 3,
              kappa = 50, ploidy = "2", maxCN = 7, estimateNormal = TRUE, estimateScPrevalence = TRUE, 
@@ -90,7 +91,16 @@ run_ichorCNA <- function(tumor_wig, normal_wig = NULL, gcWig, mapWig, repTimeWig
   
   ## load seqinfo 
   seqinfo <- getSeqInfo(genomeBuild, genomeStyle, chrs)
-  
+
+  ## check required tumor_wig & gcWig have inputs
+  if (missing(tumor_wig) || is.null(tumor_wig)) {
+    stop("tumor wig file not provided but is required")
+  }
+
+  if (missing(gcWig) || is.null(gcWig)) {
+    stop("GC wig file not provided but is required")
+  }
+
   if (substr(tumor_wig,nchar(tumor_wig)-2,nchar(tumor_wig)) == "wig") {
     wigFiles <- data.frame(cbind(id, tumor_wig))
   } else {
@@ -119,6 +129,7 @@ run_ichorCNA <- function(tumor_wig, normal_wig = NULL, gcWig, mapWig, repTimeWig
   
   ## LOAD GC/MAP/REPTIME WIG FILES ###
   message("Reading GC and mappability files")
+
   gc <- wigToGRanges(gcWig)
   if (is.null(gc)){
       stop("GC wig file not provided but is required")

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,6 +93,8 @@ setGenomeStyle <- function(x, genomeStyle = "NCBI", species = "Homo_sapiens"){
 }
 #' @export
 wigToGRanges <- function(wigfile, verbose = TRUE){
+  if(is.null(wigfile)) return(NULL)
+
   output <- tryCatch({
     input <- readLines(wigfile, warn = FALSE)
     breaks <- c(grep("fixedStep", input), length(input) + 1)


### PR DESCRIPTION
This PR make changes to the `run_ichorCNA` and `wigToGRanges` functions, so that users can skip supplying the two optional wig params (`mapWig` and `repTimeWig`) when running ichorCNA. 

```r
Error in wigToGRanges(mapWig) : 
  argument "mapWig" is missing, with no default
In addition: Warning message:
In message("wigToGRanges: WIG file '", wigfile, "' not found.") :
  restarting interrupted promise evaluation
```

```r
Error in wigToGRanges(repTimeWig) : 
  argument "repTimeWig" is missing, with no default
In addition: Warning message:
In message("wigToGRanges: WIG file '", wigfile, "' not found.") :
  restarting interrupted promise evaluation
```

I also added checks to make sure the two required params `tumor_wig` and `gcWig` are provided by users and improved the error messaging.

Previously:

```r
Error in substr(tumor_wig, nchar(tumor_wig) - 2, nchar(tumor_wig)) : 
  argument "tumor_wig" is missing, with no default
```

```r
Reading GC and mappability files
Error in wigToGRanges(gcWig) : 
  argument "gcWig" is missing, with no default
In addition: Warning message:
In message("wigToGRanges: WIG file '", wigfile, "' not found.") :
  restarting interrupted promise evaluation
```

Now

```r
Error in run_ichorCNA(id = "test", ...
  tumor wig file not provided but is required
```

```r
Error in run_ichorCNA(id = "test", ...
  GC wig file not provided but is required
```