### PR TITLE
Change dependency to require R-4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,18 +5,18 @@ Version: 0.5.0
 Date: 2022-09-08
 Author: Gavin Ha, 
 Maintainer: Gavin Ha <gha@fredhutch.org>
-Depends: R (>= 4.1.2)
+Depends: R (>= 4.2)
 biocViews:
-Imports: 
-  HMMcopy (>= 1.14.0),
-  GenomicRanges (>= 1.36.0),
-  GenomeInfoDb (>= 1.20.0),
-  doMC (>= 1.3.6),
-  foreach (>= 1.5.0),
+Imports:
+  HMMcopy (>= 1.40),
+  GenomicRanges (>= 1.50.2),
+  GenomeInfoDb (>= 1.34.9),
+  doMC (>= 1.3.8),
+  foreach (>= 1.5.2),
   BSgenome.Hsapiens.UCSC.hg19 (>= 1.4.3),
-  BSgenome.Hsapiens.UCSC.hg38 (>= 1.4.4),
-  ggplot2 (>= 3.3.5),
-  stringr (>= 1.4.0)
+  BSgenome.Hsapiens.UCSC.hg38 (>= 1.4.5),
+  ggplot2 (>= 3.4.3),
+  stringr (>= 1.5.0)
 Description: A tool for estimating the fraction of tumor in ultra-low-pass whole genome sequencing (ULP-WGS) of cell-free DNA.
 License: GPL-3
 URL: https://github.com/GavinHaLab/ichorCNA/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,8 @@ Imports:
   BSgenome.Hsapiens.UCSC.hg38 (>= 1.4.5),
   ggplot2 (>= 3.4.3),
   stringr (>= 1.5.0)
+  data.table (>= 1.14),
+  plyr (>= 1.8)
 Description: A tool for estimating the fraction of tumor in ultra-low-pass whole genome sequencing (ULP-WGS) of cell-free DNA.
 License: GPL-3
 URL: https://github.com/GavinHaLab/ichorCNA/

--- a/R/utils.R
+++ b/R/utils.R
@@ -23,16 +23,16 @@ keepChr <- function(tumour_reads, chrs = c(1:22,"X","Y")){
 	return(sort(tumour_reads))
 }
 
-# filterEmptyChr <- function(gr){
-# 	require(plyr)
-# 	ind <- daply(as.data.frame(gr), .variables = "seqnames", .fun = function(x){
-# 	  rowInd <- apply(x[, 6:ncol(x), drop = FALSE], 1, function(y){
-# 	    sum(is.na(y)) == length(y)
-# 	  })
-# 	  sum(rowInd) == nrow(x)
-# 	})	
-# 	return(GenomeInfoDb::keepSeqlevels(gr, value = names(which(!ind))))
-# }
+filterEmptyChr <- function(gr){
+	require(plyr)
+ 	ind <- daply(as.data.frame(gr), .variables = "seqnames", .fun = function(x){
+ 	  rowInd <- apply(x[, 6:ncol(x), drop = FALSE], 1, function(y){
+ 	    sum(is.na(y)) == length(y)
+ 	  })
+ 	  sum(rowInd) == nrow(x)
+ 	})
+ 	return(GenomeInfoDb::keepSeqlevels(gr, value = names(which(!ind))))
+}
 
 ####################################
 ##### FUNCTION GET SEQINFO ######


### PR DESCRIPTION
This PR change the required R version to 4.2 to run `ichorCNA`. 

This is due to a bug in `GenomeInfoDb` to handle hg38 assembly (see #11). The fixed version (v1.34.8) is available in BioC 3.16 (R-4.2). Therefore in order for `ichorCNA` to work properly when `genomeBuild = "hg38"`, it will also require to run under R-4.2.

I also updated the versions of the imported packages to the version most updated in R-4.2.