### PR TITLE
Fix counting reads when sex chromosomes aren't available

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -108,11 +108,11 @@ outputParametersToFile <- function(hmmResults, file){
 		write.table(paste0("Coverage:\t", coverage), file = fc, col.names = FALSE, 
 								row.names = FALSE, quote = FALSE, sep = "\t")
 	
-    if (!is.null(x$chrYCov)){
+    if (!is.null(x$chrYCov) || !is.na(x$chrYCov)){
       write.table(paste0("ChrY coverage fraction:\t", signif(x$chrYCov[s], digits = 4)), file = fc, col.names = FALSE, 
                   row.names = FALSE, quote = FALSE, sep = "\t")
     }
-    if (!is.null(x$chrXMedian)){
+    if (!is.null(x$chrXMedian) || !is.na(x$chrXMedian)){
       write.table(paste0("ChrX median log ratio:\t", signif(x$chrXMedian[s], digits = 4)), file = fc, col.names = FALSE, 
                   row.names = FALSE, quote = FALSE, sep = "\t")
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -251,7 +251,7 @@ getGender <- function(rawReads, normReads, gc, map, fracReadsInChrYForMale = 0.0
 	}else{
 		gender <- "unknown" # chrX is not provided
 		chrYCov <- NA
-		chrXMedian <- NULL
+		chrXMedian <- NA
 	}
 	return(list(gender=gender, chrYCovRatio=chrYCov, chrXMedian=chrXMedian))
 }


### PR DESCRIPTION
If a detected gender is unknown, the median X counts are set to `NULL`, and Y counts to `NA`. However, `NULL` doesn't have a dimension, while `NA` is a vector of length 1. This will go undetected when doing regular runs, but it will break when creating a new PoN with data without sex chromosomes, because the code will try to bind `NA` (with dimensions)    with `NULL` (no dimension), leading to a hard-to-debug-message (`arguments imply differing number of rows`).

This is fixed by setting the median chrX value to `NA`, and adjusting checks in `output.R` so that they understand that the value can also be `NA` (incidentally, the checks for chromosome Y were incomplete, they only checked for `NULL`, so `NA` is also taken into account`). 

This is not a new issue, I believe it has gone unnoticed for years.